### PR TITLE
Update YUMMI

### DIFF
--- a/src/tokens/yummi.ts
+++ b/src/tokens/yummi.ts
@@ -1,11 +1,20 @@
-import { SupplyFetcher } from "../types";
+import {defaultFetcherOptions, SupplyFetcher} from "../types";
+import {getAmountInAddresses, getBlockFrostInstance} from "../utils";
 
-const fetcher: SupplyFetcher = async () => {
-  // source: https://yummi-universe.gitbook.io/project-yummi/economics/tokenomics
-  const total = 10_000_000_000;
-  return {
-    total: total.toString(),
-  };
+const YUMMI = "078eafce5cd7edafdf63900edef2c1ea759e77f30ca81d6bbdeec92479756d6d69";
+const YUMMI_POLICY_ID = "078eafce5cd7edafdf63900edef2c1ea759e77f30ca81d6bbdeec924";
+const STAKING_ADDRESS = "addr1wydpsqf5zz9ddy76d3f3jrrf6jkpyjr48nx5a706w9y68ucy4wu6s";
+
+const fetcher: SupplyFetcher = async (options = defaultFetcherOptions) => {
+    const blockFrost = getBlockFrostInstance(options);
+    const circulating = Number(await blockFrost.assetsPolicyById(YUMMI_POLICY_ID).then((resp) => resp[0].quantity));
+    const total = 1e10;
+    const staking =
+        Number(await getAmountInAddresses(blockFrost, YUMMI, [STAKING_ADDRESS]));
+    return {
+        circulating: (circulating - staking).toString(),
+        total: total.toString(),
+    };
 };
 
 export default fetcher;

--- a/src/tokens/yummi.ts
+++ b/src/tokens/yummi.ts
@@ -1,20 +1,28 @@
-import {defaultFetcherOptions, SupplyFetcher} from "../types";
-import {getAmountInAddresses, getBlockFrostInstance} from "../utils";
+import { defaultFetcherOptions, SupplyFetcher } from "../types";
+import { getAmountInAddresses, getBlockFrostInstance } from "../utils";
 
-const YUMMI = "078eafce5cd7edafdf63900edef2c1ea759e77f30ca81d6bbdeec92479756d6d69";
-const YUMMI_POLICY_ID = "078eafce5cd7edafdf63900edef2c1ea759e77f30ca81d6bbdeec924";
-const STAKING_ADDRESS = "addr1wydpsqf5zz9ddy76d3f3jrrf6jkpyjr48nx5a706w9y68ucy4wu6s";
+const YUMMI =
+  "078eafce5cd7edafdf63900edef2c1ea759e77f30ca81d6bbdeec92479756d6d69";
+const YUMMI_POLICY_ID =
+  "078eafce5cd7edafdf63900edef2c1ea759e77f30ca81d6bbdeec924";
+const STAKING_ADDRESS =
+  "addr1wydpsqf5zz9ddy76d3f3jrrf6jkpyjr48nx5a706w9y68ucy4wu6s";
 
 const fetcher: SupplyFetcher = async (options = defaultFetcherOptions) => {
-    const blockFrost = getBlockFrostInstance(options);
-    const circulating = Number(await blockFrost.assetsPolicyById(YUMMI_POLICY_ID).then((resp) => resp[0].quantity));
-    const total = 1e10;
-    const staking =
-        Number(await getAmountInAddresses(blockFrost, YUMMI, [STAKING_ADDRESS]));
-    return {
-        circulating: (circulating - staking).toString(),
-        total: total.toString(),
-    };
+  const blockFrost = getBlockFrostInstance(options);
+  const circulating = Number(
+    await blockFrost
+      .assetsPolicyById(YUMMI_POLICY_ID)
+      .then((resp) => resp[0].quantity)
+  );
+  const total = 1e10;
+  const staking = Number(
+    await getAmountInAddresses(blockFrost, YUMMI, [STAKING_ADDRESS])
+  );
+  return {
+    circulating: (circulating - staking).toString(),
+    total: total.toString(),
+  };
 };
 
 export default fetcher;


### PR DESCRIPTION
The circulating supply now fetches from Blockfrost by using the policyid and deducts the still pending allocations from Naru NFT staking.
