### PR TITLE
Replace address of the LQ treasury

### DIFF
--- a/src/tokens/lq.ts
+++ b/src/tokens/lq.ts
@@ -7,7 +7,7 @@ const fetcher: SupplyFetcher = async (options = defaultFetcherOptions) => {
   const blockFrost = getBlockFrostInstance(options);
   const total = 21_000_000;
   const treasuryRaw = await getAmountInAddresses(blockFrost, LQ, [
-    "addr1q9qpk9suska6ugxcr76ek2l7u7d4twmugsppl3e7gkzsgu5pvftpwnj9wytn4h9e3kgdw60pwtffa6jqsll0jr5gjxnqrnmd24",
+    "stake1uxqky4shfezhz9e6mjucmyxhd8sh9557afqg0lhep6yfrfsmvq4zd",
   ]);
   const treasury = Number(treasuryRaw) / 1e6;
   return {


### PR DESCRIPTION
Since the address provided no longer contains funds due to a transaction 3 days ago, I would replace the original address with the stake key to account for all future transactions. 
(tx-hash of the mentioned transaction "c0171fcfe03b2e8fa6acd6fcc90314886eef3db4532c1ce512b6654e819e765e")