### PR TITLE
Update SNEK treasury and add burn wallet

### DIFF
--- a/src/tokens/snek.ts
+++ b/src/tokens/snek.ts
@@ -7,13 +7,19 @@ const fetcher: SupplyFetcher = async (options = defaultFetcherOptions) => {
   const blockFrost = getBlockFrostInstance(options);
   const total = 76_715_880_000;
   const treasuryRaw = await getAmountInAddresses(blockFrost, SNEK, [
-    "stake1u8ncs7903m7pxzfyrzxagzx0aey4aus2533eeqlnevw0h4qs2f82r", // $snekcointeam
     "stake1u8zjwv6a8ztrl9xkcc90utn32y4jsrxep90z2967c5aqv6cxchhhv", // $snekcoinada
+    "stake1u8ncs7903m7pxzfyrzxagzx0aey4aus2533eeqlnevw0h4qs2f82r", // $snekcoinvault
   ]);
+
+  const burnRaw = await getAmountInAddresses(blockFrost, SNEK, [
+    "addr1w8qmxkacjdffxah0l3qg8hq2pmvs58q8lcy42zy9kda2ylc6dy5r4", //$burnsnek
+  ]);
+
   const treasury = Number(treasuryRaw);
+  const burn = Number(burnRaw);
   return {
-    circulating: (total - treasury).toString(),
-    total: total.toString(),
+    circulating: (total - treasury - burn).toString(),
+    total: (total - burn).toString(),
   };
 };
 


### PR DESCRIPTION
This PR updates the SNEK supply fetcher to include an extra treasury wallet that was not included and remove any burnt SNEK from circulation as well.