### PR TITLE
fix npm run format

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "rimraf build && rollup -c rollup.config.js",
     "test": "jest",
-    "format": "prettier --write **/*.{ts,tsx} && eslint --fix --ext .ts,.tsx .",
+    "format": "prettier --write **/*.ts && eslint --fix --ext .ts",
     "check-format": "prettier --check **/*.{ts,tsx} && eslint --ext .ts,.tsx .",
     "run-market-cap": "ts-node internal/main.ts",
     "prepare": "husky install"


### PR DESCRIPTION
npm run format fails with
```
[error] No files matching the pattern were found: "**/*.tsx".
```