### PR TITLE
FLDT market-cap added

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,12 +93,14 @@ import wozFetcher from "./tokens/woz";
 import wrtFetcher from "./tokens/wrt";
 import xvyfiFetcher from "./tokens/xvyfi";
 import yummiFetcher from "./tokens/yummi";
+import fldtFetcher from "./tokens/fldt";
 import { SupplyFetcher } from "./types";
 
 export * from "./types";
 
 export const supplyFetchers: Record<string, SupplyFetcher> = {
   "29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c64d494e": minFetcher,
+  "577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e0014df10464c4454":fldtFetcher,
   f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958: agixFetcher,
   edfd7a1d77bcb8b884c474bdc92a16002d1fb720e454fa6e993444794e5458: ntxFetcher,
   "8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa4d494c4b":

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import encsFetcher from "./tokens/encs";
 import factFetcher from "./tokens/fact";
 import fetFetcher from "./tokens/fet";
 import flacFetcher from "./tokens/flac";
+import fldtFetcher from "./tokens/fldt";
 import gensFetcher from "./tokens/gens";
 import gensxFetcher from "./tokens/gensx";
 import geroFetcher from "./tokens/gero";
@@ -93,14 +94,14 @@ import wozFetcher from "./tokens/woz";
 import wrtFetcher from "./tokens/wrt";
 import xvyfiFetcher from "./tokens/xvyfi";
 import yummiFetcher from "./tokens/yummi";
-import fldtFetcher from "./tokens/fldt";
 import { SupplyFetcher } from "./types";
 
 export * from "./types";
 
 export const supplyFetchers: Record<string, SupplyFetcher> = {
   "29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c64d494e": minFetcher,
-  "577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e0014df10464c4454":fldtFetcher,
+  "577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e0014df10464c4454":
+    fldtFetcher,
   f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958: agixFetcher,
   edfd7a1d77bcb8b884c474bdc92a16002d1fb720e454fa6e993444794e5458: ntxFetcher,
   "8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa4d494c4b":

--- a/src/tokens/fldt.ts
+++ b/src/tokens/fldt.ts
@@ -1,0 +1,25 @@
+import { defaultFetcherOptions, SupplyFetcher } from "../types";
+import { getAmountInAddresses, getBlockFrostInstance } from "../utils";
+
+const FLDT = "577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e0014df10464c4454";
+
+const fetcher: SupplyFetcher = async (options = defaultFetcherOptions) => {
+  const blockFrost = getBlockFrostInstance(options);
+  const total = 100_000_000;
+  const treasuryRaw = await getAmountInAddresses(blockFrost, FLDT, [
+    "addr1w9sl503298lcpaqxtny68ex0cvxm42r2zzg2f8q9z2ggk9gw90cus",
+    "addr1w9y5n85ltkjtwe53w5ngchsr9k3lvxnqhh3hvgmhy94e9ashq6g7s",
+    "addr1wys3y9grqekln0f762mksc7daw9t53l5pappcvzz7w4zzlcuj8003",
+    "addr1w8tc2gyudj9xnp4rfs5mefcnv3l4czqmvyd2es9yazy74hczqczwu",
+    "addr1w96g27xgq67hsr8y4uha962jz7740ewqavwxftzycs4lpqgtynjww",
+    "addr1w9jcqztr0988uurdsaz63ln47e08qq6yndu40umtz22glrs32sezm",
+    "addr1wxw27ym03fwrvlcztx76p7t9spu4n0zmqg35jesjwnakuesr8q9wx",
+  ]);
+  const treasury = Number(treasuryRaw) / 1e6;
+  return {
+    circulating: (total - treasury).toString(),
+    total: total.toString(),
+  };
+};
+
+export default fetcher;


### PR DESCRIPTION
Added FLDT marketcap code, including the addresses for the vesting team, dao and farming

The only missing address is the addres where the tokens dedicated to the LBE farming will be stored