### PR TITLE
Update total supply of pavia to 1B

### DIFF
--- a/src/tokens/pavia.ts
+++ b/src/tokens/pavia.ts
@@ -5,7 +5,7 @@ const PAVIA =
   "884892bcdc360bcef87d6b3f806e7f9cd5ac30d999d49970e7a903ae5041564941";
 
 const fetcher: SupplyFetcher = async (options = defaultFetcherOptions) => {
-  const total = 2e9;
+  const total = 1e9;
   const blockFrost = getBlockFrostInstance(options);
   const treasury = await getAmountInAddresses(blockFrost, PAVIA, [
     "stake1uxy8jh76wavelv6nc3mjnka0v5uveu45znq3aykx90lam4cdxdumd",


### PR DESCRIPTION
1B of Pavia has been sent to a burn account in this transaction: a1ab938ccad58613dad5db8defbef22e7346b9b105d02fc2a956e36e066af294.

Have updated the total of pavia accordingly.