### PR TITLE
Add milkv2 treasury and rewards address

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ import liqwidFetcher from "./tokens/lq";
 import mayzFetcher from "./tokens/mayz";
 import meldFetcher from "./tokens/meld";
 import milkFetcher from "./tokens/milk";
+import milkv2Fetcher from "./tokens/milkv2";
 import minFetcher from "./tokens/min";
 import mintFetcher from "./tokens/mint";
 import mntFetcher from "./tokens/mnt";
@@ -272,4 +273,6 @@ export const supplyFetchers: Record<string, SupplyFetcher> = {
     viperFetcher,
   "285b65ae63d4fad36321384ec61edfd5187b8194fff89b5abe9876da414e47454c53":
     angelsFetcher,
+  afbe91c0b44b3040e360057bf8354ead8c49c4979ae6ab7c4fbdc9eb4d494c4b7632:
+    milkv2Fetcher,
 };

--- a/src/tokens/milkv2.ts
+++ b/src/tokens/milkv2.ts
@@ -1,0 +1,23 @@
+import { defaultFetcherOptions, SupplyFetcher } from "../types";
+import { getAmountInAddresses, getBlockFrostInstance } from "../utils";
+
+const MILKv2 =
+  "afbe91c0b44b3040e360057bf8354ead8c49c4979ae6ab7c4fbdc9eb4d494c4b7632";
+
+const fetcher: SupplyFetcher = async (options = defaultFetcherOptions) => {
+  const blockFrost = getBlockFrostInstance(options);
+  const total = 10_000_000; // 10 Million with 6 decimals
+  const treasury =
+    Number(
+      await getAmountInAddresses(blockFrost, MILKv2, [
+        "addr1q9rtclgcvqwhutjnkr3acfgetxn2f6qjkzjcdc4m5fes868g8gfztpemy35qyh208nz9fp2gh5pnc2z6zkcrleyp4j0s8x3g5c", // treasury
+        "addr1v8h4fm4ejd9w8wr8lkkeu0pe4m00ycl2vysd3jvs9mgw7ps8sm9rt", // yield rewards
+      ])
+    ) / 1e6;
+  return {
+    circulating: (total - treasury).toString(),
+    total: total.toString(),
+  };
+};
+
+export default fetcher;


### PR DESCRIPTION
This adds the circulating supply for the MILK v2 token (after token migration)