### PR TITLE
Count yield rewards from circulating supply and transformed tokens

### DIFF
--- a/src/tokens/milk.ts
+++ b/src/tokens/milk.ts
@@ -7,7 +7,9 @@ const fetcher: SupplyFetcher = async (options = defaultFetcherOptions) => {
   const blockFrost = getBlockFrostInstance(options);
   const total = 10_000_000n;
   const treasury = await getAmountInAddresses(blockFrost, MILK, [
-    "addr1v8c3mztrzpjqxzrcl8rvxln8xyvanz6pufuaju7rwkglnychv3cg3",
+    "addr1v8c3mztrzpjqxzrcl8rvxln8xyvanz6pufuaju7rwkglnychv3cg3", // treasury
+    "addr1v8h4fm4ejd9w8wr8lkkeu0pe4m00ycl2vysd3jvs9mgw7ps8sm9rt", // yield rewards
+    "addr1q9rtclgcvqwhutjnkr3acfgetxn2f6qjkzjcdc4m5fes868g8gfztpemy35qyh208nz9fp2gh5pnc2z6zkcrleyp4j0s8x3g5c", // treasury
   ]);
   return {
     circulating: (total - treasury).toString(),


### PR DESCRIPTION
The deprecated MILK will be calculated in the transformation treasury, which should hence not count towards the circulating supply of v1 MILK

Moreover the yield rewards that are not distributed yet should also not count and have been added.